### PR TITLE
Limit prefetch count of listeners

### DIFF
--- a/events/consumer.py
+++ b/events/consumer.py
@@ -150,7 +150,14 @@ class EventConsumer(object):
         logger.debug('Channel opened')
         self._channel = channel
         self.add_on_channel_close_callback()
+        self.setup_qos()
 
+    def setup_qos(self):
+        """Configure QoS to limit number of messages to prefetch """
+        self._channel.basic_qos(prefetch_count=1, callback=self.on_qos_set)
+
+    def on_qos_set(self, _):
+        """Will be invoked when the QoS is configured"""
         if self._exchange:
             self.setup_exchange()
         else:


### PR DESCRIPTION
This should make balancing of jobs between queues fairer, because each queue will only consume one message at a time.