### PR TITLE
decode body to utf-8 before json.loads

### DIFF
--- a/amqpconsumer/events.py
+++ b/amqpconsumer/events.py
@@ -295,7 +295,7 @@ class EventConsumer(object):
         """
         logger.debug('Received message # %s from %s: %s', basic_deliver.delivery_tag, properties.app_id, body)
         try:
-            decoded = json.loads(body)
+            decoded = json.loads(body.decode('-utf-8'))
         except ValueError:
             logger.warning('Discarding message containing invalid json: %s', body)
         else:


### PR DESCRIPTION
In Python 3 json.loads() will only accept a unicode string

also see: http://stackoverflow.com/a/29781023/4158804

fixes:
```
298, in on_message
   decoded = json.loads(body)
 File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
   s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```