### PR TITLE
Fix all ordering issues for newer pika methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='amqpconsumer',
-    version='1.7.3',
+    version='1.7.4',
     description='AMQP event listener',
     url='https://github.com/ByteInternet/amqpconsumer',
     author='Byte B.V.',


### PR DESCRIPTION
Newer pika versions changed the ordering of some parameters in the
method signature. This is kind of hard to test so we keep running into
different issues. I've now just made sure that any pika function call
has the correct kwarg provided so ordering won't matter anymore.